### PR TITLE
Added Kubernetes deployment example manifests.

### DIFF
--- a/open-distro-elasticsearch-kubernetes/LICENSE
+++ b/open-distro-elasticsearch-kubernetes/LICENSE
@@ -1,0 +1,14 @@
+Copyright [first edit year]-[latest edit year] Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this
+software and associated documentation files (the "Software"), to deal in the Software
+without restriction, including without limitation the rights to use, copy, modify,
+merge, publish, distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/open-distro-elasticsearch-kubernetes/LICENSE
+++ b/open-distro-elasticsearch-kubernetes/LICENSE
@@ -1,4 +1,4 @@
-Copyright [first edit year]-[latest edit year] Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of this
 software and associated documentation files (the "Software"), to deal in the Software

--- a/open-distro-elasticsearch-kubernetes/README.md
+++ b/open-distro-elasticsearch-kubernetes/README.md
@@ -1,0 +1,311 @@
+# Open Distro for Elasticsearch Deployment for Kubernetes
+
+## Elasticsearch Deployment
+
+### Initial resource creation
+
+With your EKS credentials loaded as part of your `kubeconfig`, you can start the creation of the first few items using the following commands:
+
+```
+kubectl apply -f 10-es-namespace.yml
+kubectl apply -f 20-es-svc-discovery.yml
+kubectl apply -f 20-es-service-account.yml
+kubectl apply -f 25-es-sc-gp2.yml
+kubectl apply -f 35-es-service.yml
+```
+
+### Elasticsearch master nodes
+
+Deploy the Elasticsearch master nodes using command:
+
+```
+kubectl apply -f 40-es-master-deploy.yml
+```
+
+Check for the master node pods to come up using command:
+
+```
+kubectl -n elasticsearch get pods
+```
+
+If the master nodes are up and running correctly, output would be something like this:
+
+```
+NAME                         READY     STATUS    RESTARTS   AGE
+es-master-78f97f98d9-275sl   1/1       Running   0          1d
+es-master-78f97f98d9-kwqxt   1/1       Running   0          1d
+es-master-78f97f98d9-lp6bn   1/1       Running   0          1d
+```
+
+You can see whether the master nodes are successfully running by checking the log output of any of these master nodes using the command:
+
+```
+kubectl -n elasticsearch logs -f es-master-78f97f98d9-275sl
+```
+
+If the log output contains the following message, it means that the Elasticsearch master nodes have clustered successfully:
+
+`[2019-04-04T06:34:16,816][INFO ][o.e.c.s.ClusterApplierService] [es-master-78f97f98d9-275sl] detected_master {es-master-78f97f98d9-kwqxt}`
+
+### Elasticsearch client nodes
+
+Deploy the Elasticsearch client nodes using the command:
+
+```
+kubectl apply -f `50-es-client-deploy.yml`
+```
+
+Check for the master node pods to come up using the command:
+
+```
+kubectl -n elasticsearch get pods
+```
+
+If the client nodes are up and running, output would be something like this:
+
+```
+NAME                         READY     STATUS    RESTARTS   AGE
+es-client-855f48886-75cz8    1/1       Running   0          1d
+es-client-855f48886-r4vzn    1/1       Running   0          1d
+es-master-78f97f98d9-275sl   1/1       Running   0          1d
+es-master-78f97f98d9-kwqxt   1/1       Running   0          1d
+es-master-78f97f98d9-lp6bn   1/1       Running   0          1d
+```
+
+You can see if the client nodes are successfully running by checking the log output of any of these client nodes using command:
+
+```
+kubectl -n elasticsearch logs -f es-master-78f97f98d9-275sl
+```
+
+If the log output contains the following message, it means that the Elasticsearch client nodes have clustered successfully:
+`[2019-04-04T06:35:57,180][INFO ][o.e.c.s.ClusterApplierService] [es-client-855f48886-75cz8] detected_master {es-master-78f97f98d9-kwqxt}`
+
+### Elasticsearch Data Nodes
+
+Deploy the Elasticsearch data nodes using the command:
+
+```
+kubectl apply -f 70-es-data-sts.yml
+```
+
+Check for the data node pods to come up using the command:
+
+```
+kubectl -n elasticsearch get pods
+```
+
+If the data nodes are up and running, output would be something like this :
+
+```
+NAME                         READY     STATUS    RESTARTS   AGE
+es-client-855f48886-75cz8    1/1       Running   0          1d
+es-client-855f48886-r4vzn    1/1       Running   0          1d
+es-data-0                    1/1       Running   0          1d
+es-data-1                    1/1       Running   0          1d
+es-data-2                    1/1       Running   0          1d
+es-master-78f97f98d9-275sl   1/1       Running   0          1d
+es-master-78f97f98d9-kwqxt   1/1       Running   0          1d
+es-master-78f97f98d9-lp6bn   1/1       Running   0          1d
+```
+
+You can see whether the data nodes are successfully running by checking the log output of any of these data nodes using the command:
+
+```
+kubectl -n elasticsearch logs -f es-data-0
+```
+
+If the log output contains the following message, it means that Elasticsearch data nodes have clustered successfully and are ready to start indexing data:
+`[2019-04-04T06:37:57,208][INFO ][o.e.c.s.ClusterApplierService] [es-data-0] detected_master {es-master-78f97f98d9-kwqxt}`
+
+At this point the cluster has been successfully deployed, but you still need to initialize it with the default users and their passwords.
+
+### Cluster Security Initialization
+
+As described in the [documentation for Open Distro for Elasticsearch](https://opendistro.github.io/for-elasticsearch-docs/docs/install/docker-security/), after deployment a cluster has to be initialized with security before it can be made available for use. This is done through two files that reside on the containers running Elasticsearch.
+
+To start the initialization process, use the following command to gain shell access to one of master nodes:
+
+```
+kubectl -n elasticsearch exec -it es-master-78f97f98d9-275sl -- bash
+```
+
+Once inside, navigate to `/usr/share/elasticsearch/plugins/opendistro_security/tools` and execute the following command:
+
+```
+chmod +x hash.sh
+```
+
+This will make the password hashing script executable. Now we will use this script to generate bcrypt hashed passwords for our default users. The default users can be seen in file `/usr/share/elasticsearch/plugins/opendistro_security/securityconfig/internal_users.yml` which by default looks like:
+
+```
+# This is the internal user database
+# The hash value is a bcrypt hash and can be generated with plugin/tools/hash.sh
+
+# Still using default password: admin
+admin:
+  readonly: true
+  hash: $2y$12$SFNvhLHf7MPCpRCq00o/BuU8GMdcD.7BymhT80YHNISBHsfJwhTou
+  roles:
+    - admin
+  attributes:
+    #no dots allowed in attribute names
+    attribute1: value1
+    attribute2: value2
+    attribute3: value3
+
+# Still using default password: logstash
+logstash:
+  hash: $2a$12$u1ShR4l4uBS3Uv59Pa2y5.1uQuZBrZtmNfqB3iM/.jL0XoV9sghS2
+  roles:
+    - logstash
+
+# New password applied
+kibanaserver:
+  readonly: true
+  hash: $2a$12$4AcgAt3xwOWadA5s5blL6ev39OXDNhmOesEoo33eZtrq2N0YrU3H.
+
+# Still using default password: kibanaro
+kibanaro:
+  hash: $2a$12$JJSXNfTowz7Uu5ttXfeYpeYE0arACvcwlPBStB1F.MI7f0U9Z4DGC
+  roles:
+    - kibanauser
+    - readall
+
+# Still using default password: readall
+readall:
+  hash: $2a$12$ae4ycwzwvLtZxwZ82RmiEunBbIPiAmGZduBAjKN0TXdwQFtCwARz2
+  #password is: readall
+  roles:
+    - readall
+
+# Still using default password: snapshotrestore
+snapshotrestore:
+  hash: $2y$12$DpwmetHKwgYnorbgdvORCenv4NAK8cPUg8AI6pxLCuWf/ALc0.v7W
+  roles:
+    - snapshotrestore
+```
+
+To change the passwords in the `internal_users.yml` file, start by generating hashed passwords for each user in the file using the `hash.sh` script. Use the following command:
+
+```
+./hash.sh -p <password you want to hash>
+```
+
+For example, if I want to change the password of the admin user, I would do the following:
+
+```
+[root@es-master-78f97f98d9-275sl tools]# ./hash.sh -p ThisIsAStrongPassword9876212
+$2y$12$yMchvPrjvqbwweYihFiDyePfUj3CEqgps3X1ACciPjtbibGUExsiu
+```
+
+The output string is the bcrypt hashed password. We will now replace the hash for admin user in the `internal_users.yml` file with this hash, resulting in the file looking like this:
+
+```
+# This is the internal user database
+# The hash value is a bcrypt hash and can be generated with plugin/tools/hash.sh
+
+# Password changed for user admin
+admin:
+  readonly: true
+  hash: $2y$12$yMchvPrjvqbwweYihFiDyePfUj3CEqgps3X1ACciPjtbibGUExsiu
+  roles:
+    - admin
+  attributes:
+    #no dots allowed in attribute names
+    attribute1: value1
+    attribute2: value2
+    attribute3: value3
+
+# Still using default password: logstash
+logstash:
+  hash: $2a$12$u1ShR4l4uBS3Uv59Pa2y5.1uQuZBrZtmNfqB3iM/.jL0XoV9sghS2
+  roles:
+    - logstash
+
+# New password applied
+kibanaserver:
+  readonly: true
+  hash: $2a$12$4AcgAt3xwOWadA5s5blL6ev39OXDNhmOesEoo33eZtrq2N0YrU3H.
+
+# Still using default password: kibanaro
+kibanaro:
+  hash: $2a$12$JJSXNfTowz7Uu5ttXfeYpeYE0arACvcwlPBStB1F.MI7f0U9Z4DGC
+  roles:
+    - kibanauser
+    - readall
+
+# Still using default password: readall
+readall:
+  hash: $2a$12$ae4ycwzwvLtZxwZ82RmiEunBbIPiAmGZduBAjKN0TXdwQFtCwARz2
+  #password is: readall
+  roles:
+    - readall
+
+# Still using default password: snapshotrestore
+snapshotrestore:
+  hash: $2y$12$DpwmetHKwgYnorbgdvORCenv4NAK8cPUg8AI6pxLCuWf/ALc0.v7W
+  roles:
+    - snapshotrestore
+```
+
+Do this for each default user in this file and store the plaintext version of the password securely, as some of these will be required in future deployment.
+
+Initialize using `/usr/share/elasticsearch/plugins/opendistro_security/tools/securityadmin.sh` script.
+
+The initialization command requires certain parameters, and should look like this:
+`/usr/share/elasticsearch/plugins/opendistro_security/tools/securityadmin.sh -cacert /usr/share/elasticsearch/config/admin-root-ca.pem -cert /usr/share/elasticsearch/config/admin-crt.pem -key /usr/share/elasticsearch/config/admin-key.pem -cd /usr/share/elasticsearch/plugins/opendistro_security/securityconfig/ -keypass <replace-with-passphrase-for-admin-private-key> -h <replace-with-IP-of-master-nodes> -nhnv -icl`
+
+This command specifies what admin client TLS certificate and private key to use to execute the script successfully. This are the second set of certificates that we loaded earlier as part of the ConfigMap. The -cd flag specifies the directory in which the initialization configs are stored. The -keypass flag must be set to the passphrase chosen when the admin client private key was generated. The -h flag specifies what hostname to use, in this case the internal IP address of the pod we're shelling into.
+
+If it runs successfully and is able to initialize the cluster, the output will look like the following:
+
+```
+Open Distro Security Admin v6
+Will connect to 10.30.128.125:9300 ... done
+Elasticsearch Version: 6.5.4
+Open Distro Security Version: 0.7.0.1
+Connected as CN=admin.example.com
+Contacting elasticsearch cluster 'elasticsearch' and wait for YELLOW clusterstate ...
+Clustername: logs
+Clusterstate: GREEN
+Number of nodes: 8
+Number of data nodes: 3
+.opendistro_security index already exists, so we do not need to create one.
+Populate config from /usr/share/elasticsearch/plugins/opendistro_security/securityconfig/
+Will update 'security/config' with /usr/share/elasticsearch/plugins/opendistro_security/securityconfig/config.yml
+   SUCC: Configuration for 'config' created or updated
+Will update 'security/roles' with /usr/share/elasticsearch/plugins/opendistro_security/securityconfig/roles.yml
+   SUCC: Configuration for 'roles' created or updated
+Will update 'security/rolesmapping' with /usr/share/elasticsearch/plugins/opendistro_security/securityconfig/roles_mapping.yml
+   SUCC: Configuration for 'rolesmapping' created or updated
+Will update 'security/internalusers' with /usr/share/elasticsearch/plugins/opendistro_security/securityconfig/internal_users.yml
+   SUCC: Configuration for 'internalusers' created or updated
+Will update 'security/actiongroups' with /usr/share/elasticsearch/plugins/opendistro_security/securityconfig/action_groups.yml
+   SUCC: Configuration for 'actiongroups' created or updated
+Done with success
+```
+
+Your Elasticsearch cluster has now been successfully deployed, configured, and initialized!
+
+## Kibana Deployment
+
+Start deploying Kibana now using the following commands:
+
+```
+kubectl apply -f 10-kb-namespace.yml
+kubectl apply -f 20-kb-configmap.yml
+kubectl apply -f 30-kb-deploy.yml
+kubectl apply -f 40-kb-service.yml
+```
+
+Kibana will take a few moments to get up and running.
+
+You should be able to access the Kibana UI on [https://kibana.sec.example.com](https://kibana.sec.example.com/).
+
+## Acknowledgements
+
+* [Zack Doherty](https://github.com/zdoherty) (Senior SRE - Tinder Engineering) for all his help with Kubernetes internals
+* [Pires](https://github.com/pires) for his work on the Open-source Elasticsearch deployment in Kubernetes
+* Open Distro for Elasticsearch team for their support and guidance in writing this AWS Blog Post
+* Ring Security Team for their support and encouragement

--- a/open-distro-elasticsearch-kubernetes/elasticsearch/10-es-namespace.yml
+++ b/open-distro-elasticsearch-kubernetes/elasticsearch/10-es-namespace.yml
@@ -1,0 +1,10 @@
+# Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: MIT-0
+
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: elasticsearch
+  labels:
+    name: elasticsearch

--- a/open-distro-elasticsearch-kubernetes/elasticsearch/20-es-service-account.yml
+++ b/open-distro-elasticsearch-kubernetes/elasticsearch/20-es-service-account.yml
@@ -1,0 +1,11 @@
+# Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: MIT-0
+
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    app: elasticsearch
+  name: elasticsearch
+  namespace: elasticsearch

--- a/open-distro-elasticsearch-kubernetes/elasticsearch/20-es-svc-discovery.yml
+++ b/open-distro-elasticsearch-kubernetes/elasticsearch/20-es-svc-discovery.yml
@@ -1,0 +1,21 @@
+# Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: MIT-0
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: elasticsearch-discovery
+  namespace: elasticsearch
+  labels:
+    component: elasticsearch
+    role: master
+spec:
+  selector:
+    component: elasticsearch
+    role: master
+  ports:
+  - name: transport
+    port: 9300
+    protocol: TCP
+  clusterIP: None

--- a/open-distro-elasticsearch-kubernetes/elasticsearch/25-es-sc-gp2.yml
+++ b/open-distro-elasticsearch-kubernetes/elasticsearch/25-es-sc-gp2.yml
@@ -1,0 +1,13 @@
+# Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: MIT-0
+
+---
+kind: StorageClass
+apiVersion: storage.k8s.io/v1
+metadata:
+  name: elk-gp2
+  namespace: elasticsearch
+provisioner: kubernetes.io/aws-ebs
+parameters:
+  type: gp2
+reclaimPolicy: Delete

--- a/open-distro-elasticsearch-kubernetes/elasticsearch/30-es-configmap.yml
+++ b/open-distro-elasticsearch-kubernetes/elasticsearch/30-es-configmap.yml
@@ -1,0 +1,128 @@
+# Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: MIT-0
+
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: elasticsearch
+  namespace: elasticsearch
+  labels:
+    app: elasticsearch
+data:
+  elk-crt.pem: |-
+    -----BEGIN CERTIFICATE-----
+    <CERTIFICATE_DATA_REDACTED>
+    -----END CERTIFICATE-----
+    -----BEGIN CERTIFICATE-----
+    <CERTIFICATE_DATA_REDACTED>
+    -----END CERTIFICATE-----
+
+  elk-key.pem: |-
+    -----BEGIN ENCRYPTED PRIVATE KEY-----
+    <CERTIFICATE_DATA_REDACTED>
+    -----END ENCRYPTED PRIVATE KEY-----
+
+  elk-root-ca.pem: |-
+    -----BEGIN CERTIFICATE-----
+    <CERTIFICATE_DATA_REDACTED>
+    -----END CERTIFICATE-----
+
+  admin-crt.pem: |-
+    -----BEGIN CERTIFICATE-----
+    <CERTIFICATE_DATA_REDACTED>
+    -----END CERTIFICATE-----
+    -----BEGIN CERTIFICATE-----
+    <CERTIFICATE_DATA_REDACTED>
+    -----END CERTIFICATE-----
+
+  admin-key.pem: |-
+    -----BEGIN ENCRYPTED PRIVATE KEY-----
+    <CERTIFICATE_DATA_REDACTED>
+    -----END ENCRYPTED PRIVATE KEY-----
+
+  admin-root-ca.pem: |-
+    -----BEGIN CERTIFICATE-----
+    <CERTIFICATE_DATA_REDACTED>
+    -----END CERTIFICATE-----
+
+  elasticsearch.yml: |-
+    cluster:
+      name: ${CLUSTER_NAME}
+    node:
+      master: ${NODE_MASTER}
+      data: ${NODE_DATA}
+      name: ${NODE_NAME}
+      ingest: ${NODE_INGEST}
+      max_local_storage_nodes: 1
+      attr.box_type: hot
+
+    processors: ${PROCESSORS:1}
+
+    network.host: ${NETWORK_HOST}
+
+    thread_pool.bulk.queue_size: 800
+
+    path:
+      data: /usr/share/elasticsearch/data
+      logs: /usr/share/elasticsearch/logs
+
+    http:
+      enabled: ${HTTP_ENABLE}
+      compression: true
+
+    discovery:
+      zen:
+        ping.unicast.hosts: ${DISCOVERY_SERVICE}
+        minimum_master_nodes: ${NUMBER_OF_MASTERS}
+
+    # TLS Configuration Transport Layer
+    opendistro_security.ssl.transport.pemcert_filepath: elk-crt.pem
+    opendistro_security.ssl.transport.pemkey_filepath: elk-key.pem
+    opendistro_security.ssl.transport.pemtrustedcas_filepath: elk-root-ca.pem
+    opendistro_security.ssl.transport.pemkey_password: <KEY_PASSPHRASE_REDACTED>
+    opendistro_security.ssl.transport.enforce_hostname_verification: false
+
+    # TLS Configuration REST Layer
+    opendistro_security.ssl.http.enabled: true
+    opendistro_security.ssl.http.pemcert_filepath: elk-crt.pem
+    opendistro_security.ssl.http.pemkey_filepath: elk-key.pem
+    opendistro_security.ssl.http.pemtrustedcas_filepath: elk-root-ca.pem
+    opendistro_security.ssl.http.pemkey_password: <KEY_PASSPHRASE_REDACTED>
+
+    # Demo Certificate Option Disabled
+    opendistro_security.allow_unsafe_democertificates: false
+
+    opendistro_security.allow_default_init_securityindex: true
+
+    opendistro_security.authcz.admin_dn:
+      - CN=admin.example.com
+    opendistro_security.nodes_dn:
+      - 'CN=sec.other.com,OU=SSL,O=Test,L=Test,C=DE'
+      - 'CN=*.example.com,OU=SSL,O=Test,L=Test,C=DE'
+      - 'CN=*.sec.example.com'
+      - 'CN=sec.examples.com'
+
+    opendistro_security.audit.type: internal_elasticsearch
+    opendistro_security.enable_snapshot_restore_privilege: true
+    opendistro_security.check_snapshot_restore_write_privileges: true
+    opendistro_security.restapi.roles_enabled: ["all_access", "security_rest_api_access"]
+    cluster.routing.allocation.disk.threshold_enabled: false
+    opendistro_security.audit.config.disabled_rest_categories: NONE
+    opendistro_security.audit.config.disabled_transport_categories: NONE
+
+  logging.yml: |-
+    # you can override this using by setting a system property, for example -Des.logger.level=DEBUG
+    es.logger.level: INFO
+    rootLogger: ${es.logger.level}, console
+    logger:
+      # log action execution errors for easier debugging
+      action: DEBUG
+      # reduce the logging for aws, too much is logged under the default INFO
+      com.amazonaws: WARN
+    appender:
+      console:
+        type: console
+        layout:
+          type: consolePattern
+          conversionPattern: "[%d{ISO8601}][%-5p][%-25c] %m%n"

--- a/open-distro-elasticsearch-kubernetes/elasticsearch/35-es-service.yml
+++ b/open-distro-elasticsearch-kubernetes/elasticsearch/35-es-service.yml
@@ -1,0 +1,41 @@
+# Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: MIT-0
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    # Service external-dns has to be deployed for this A record to be created in AWS Route53
+    external-dns.alpha.kubernetes.io/hostname: elk.sec.example.com
+
+    # Defined ELB backend protocol as HTTPS to allow connection to Elasticsearch API
+    service.beta.kubernetes.io/aws-load-balancer-backend-protocol: https
+
+    # ARN of ACM certificate registered to the deployed ELB for handling connections over TLS
+    # ACM certificate should be issued to the DNS hostname defined earlier (elk.sec.example.com)
+    service.beta.kubernetes.io/aws-load-balancer-ssl-cert: "arn:aws:acm:us-east-1:111222333444:certificate/c69f6022-b24f-43d9-b9c8-dfe288d9443d"
+    service.beta.kubernetes.io/aws-load-balancer-ssl-ports: "https"
+    service.beta.kubernetes.io/aws-load-balancer-connection-draining-enabled: "true"
+    service.beta.kubernetes.io/aws-load-balancer-connection-draining-timeout: "60"
+    service.beta.kubernetes.io/aws-load-balancer-cross-zone-load-balancing-enabled: "true"
+
+    # Annotation to create internal only ELB
+    service.beta.kubernetes.io/aws-load-balancer-internal: 0.0.0.0/0
+  labels:
+    component: elasticsearch
+    role: client
+  name: elasticsearch
+  namespace: elasticsearch
+spec:
+  ports:
+    - name: http
+      port: 9200
+    - name: transport
+      port: 9300
+    - name: metrics
+      port: 9600
+  selector:
+    component: elasticsearch
+    role: client
+  type: LoadBalancer

--- a/open-distro-elasticsearch-kubernetes/elasticsearch/40-es-master-deploy.yml
+++ b/open-distro-elasticsearch-kubernetes/elasticsearch/40-es-master-deploy.yml
@@ -1,0 +1,138 @@
+# Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: MIT-0
+
+---
+apiVersion: apps/v1beta1
+kind: Deployment
+metadata:
+  labels:
+    component: elasticsearch
+    role: master
+  name: es-master
+  namespace: elasticsearch
+spec:
+  replicas: 3
+  template:
+    metadata:
+      labels:
+        component: elasticsearch
+        role: master
+      annotations:
+        iam.amazonaws.com/role: <ARN_OF_IAM_ROLE_FOR_CONTAINER>
+    spec:
+      # Add toleration for not scheduling on dedicated node
+      tolerations:
+      - key: dedicated
+        value: "true"
+        effect: NoSchedule
+      # Anti-affinity to disallow deploying client and master nodes on the same worker node
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - topologyKey: "kubernetes.io/hostname"
+            labelSelector:
+              matchLabels:
+                component: elasticsearch
+                role: master
+        # Node Affinity to attract this Deployment's pods to a specific set of worker nodes
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: type # Replace this with corresponding worker node label's key
+                operator: In
+                values:
+                - general # Replace this with corresponding worker node label's value
+      initContainers:
+      - name: init-sysctl
+        image: busybox:1.27.2
+        command:
+        - sysctl
+        - -w
+        - vm.max_map_count=262144
+        securityContext:
+          privileged: true
+      containers:
+      - name: elasticsearch
+        env:
+        - name: CLUSTER_NAME
+          value: logs
+        - name: NUMBER_OF_MASTERS
+          value: "3"
+        - name: NODE_MASTER
+          value: "true"
+        - name: NODE_INGEST
+          value: "false"
+        - name: NODE_DATA
+          value: "false"
+        - name: NETWORK_HOST
+          value: "0.0.0.0"
+        - name: HTTP_ENABLE
+          value: "true"
+        - name: NODE_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: DISCOVERY_SERVICE
+          value: elasticsearch-discovery
+        - name: KUBERNETES_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: PROCESSORS
+          valueFrom:
+            resourceFieldRef:
+              resource: limits.cpu
+        - name: ES_JAVA_OPTS
+          value: -Xms6g -Xmx6g
+        resources:
+          requests:
+            memory: 12Gi
+            cpu: 2
+          limits:
+            memory: 12Gi
+            cpu: 2
+        livenessProbe:
+          tcpSocket:
+            port: transport
+          initialDelaySeconds: 60
+          periodSeconds: 10
+        # Official Image from Open Distro Team
+        image: amazon/opendistro-for-elasticsearch:0.8.0
+        imagePullPolicy: Always
+        ports:
+        - containerPort: 9300
+          name: transport
+        - containerPort: 9200
+          name: http
+        - containerPort: 9600
+          name: metrics
+        volumeMounts:
+        - mountPath: /usr/share/elasticsearch/config/elasticsearch.yml
+          name: config
+          subPath: elasticsearch.yml
+        - mountPath: /usr/share/elasticsearch/config/logging.yml
+          name: config
+          subPath: logging.yml
+        - mountPath: /usr/share/elasticsearch/config/elk-crt.pem
+          name: config
+          subPath: elk-crt.pem
+        - mountPath: /usr/share/elasticsearch/config/elk-key.pem
+          name: config
+          subPath: elk-key.pem
+        - mountPath: /usr/share/elasticsearch/config/elk-root-ca.pem
+          name: config
+          subPath: elk-root-ca.pem
+        - mountPath: /usr/share/elasticsearch/config/admin-crt.pem
+          name: config
+          subPath: admin-crt.pem
+        - mountPath: /usr/share/elasticsearch/config/admin-key.pem
+          name: config
+          subPath: admin-key.pem
+        - mountPath: /usr/share/elasticsearch/config/admin-root-ca.pem
+          name: config
+          subPath: admin-root-ca.pem
+      volumes:
+      - name: config
+        configMap:
+          name: elasticsearch

--- a/open-distro-elasticsearch-kubernetes/elasticsearch/50-es-client-deploy.yml
+++ b/open-distro-elasticsearch-kubernetes/elasticsearch/50-es-client-deploy.yml
@@ -1,0 +1,140 @@
+# Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: MIT-0
+
+---
+apiVersion: apps/v1beta1
+kind: Deployment
+metadata:
+  labels:
+    component: elasticsearch
+    role: client
+  name: es-client
+  namespace: elasticsearch
+spec:
+  replicas: 2
+  template:
+    metadata:
+      labels:
+        component: elasticsearch
+        role: client
+      annotations:
+        iam.amazonaws.com/role: <ARN_OF_IAM_ROLE_FOR_CONTAINER>
+    spec:
+      serviceAccountName: elasticsearch
+      # Add toleration for not scheduling on dedicated node
+      tolerations:
+      - key: dedicated
+        value: "true"
+        effect: NoSchedule
+      # Weighted anti-affinity to disallow deploying client node to the same worker node as master node
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - weight: 1
+              podAffinityTerm:
+                topologyKey: "kubernetes.io/hostname"
+                labelSelector:
+                  matchLabels:
+                    component: elasticsearch
+                    role: client
+        # Node Affinity to attract this Deployment's pods to a specific set of worker nodes
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: type # Replace this with corresponding worker node label's key
+                operator: In
+                values:
+                - general # Replace this with corresponding worker node label's value
+      initContainers:
+      - name: init-sysctl
+        image: busybox:1.27.2
+        command:
+        - sysctl
+        - -w
+        - vm.max_map_count=262144
+        securityContext:
+          privileged: true
+      containers:
+      - name: elasticsearch
+        env:
+        - name: CLUSTER_NAME
+          value: logs
+        - name: NUMBER_OF_MASTERS
+          value: "3"
+        - name: NODE_MASTER
+          value: "false"
+        - name: NODE_INGEST
+          value: "true"
+        - name: NODE_DATA
+          value: "false"
+        - name: HTTP_ENABLE
+          value: "true"
+        - name: NETWORK_HOST
+          value: "_eth0_"
+        - name: NODE_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: DISCOVERY_SERVICE
+          value: elasticsearch-discovery
+        - name: KUBERNETES_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: PROCESSORS
+          valueFrom:
+            resourceFieldRef:
+              resource: limits.cpu
+        - name: ES_JAVA_OPTS
+          value: -Xms6g -Xmx6g
+        resources:
+          requests:
+            cpu: 2
+            memory: 12Gi
+          limits:
+            cpu: 2
+            memory: 12Gi
+        # Official Image from Open Distro Team
+        image: amazon/opendistro-for-elasticsearch:0.8.0
+        imagePullPolicy: Always
+        ports:
+        - containerPort: 9200
+          name: http
+        - containerPort: 9300
+          name: transport
+        - containerPort: 9600
+          name: metrics
+        livenessProbe:
+          tcpSocket:
+            port: transport
+          initialDelaySeconds: 60
+        volumeMounts:
+        - mountPath: /usr/share/elasticsearch/config/elasticsearch.yml
+          name: config
+          subPath: elasticsearch.yml
+        - mountPath: /usr/share/elasticsearch/config/logging.yml
+          name: config
+          subPath: logging.yml
+        - mountPath: /usr/share/elasticsearch/config/elk-crt.pem
+          name: config
+          subPath: elk-crt.pem
+        - mountPath: /usr/share/elasticsearch/config/elk-key.pem
+          name: config
+          subPath: elk-key.pem
+        - mountPath: /usr/share/elasticsearch/config/elk-root-ca.pem
+          name: config
+          subPath: elk-root-ca.pem
+        - mountPath: /usr/share/elasticsearch/config/admin-crt.pem
+          name: config
+          subPath: admin-crt.pem
+        - mountPath: /usr/share/elasticsearch/config/admin-key.pem
+          name: config
+          subPath: admin-key.pem
+        - mountPath: /usr/share/elasticsearch/config/admin-root-ca.pem
+          name: config
+          subPath: admin-root-ca.pem
+      volumes:
+      - name: config
+        configMap:
+          name: elasticsearch

--- a/open-distro-elasticsearch-kubernetes/elasticsearch/60-es-data-svc.yml
+++ b/open-distro-elasticsearch-kubernetes/elasticsearch/60-es-data-svc.yml
@@ -1,0 +1,24 @@
+# Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: MIT-0
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: elasticsearch-data
+  labels:
+    component: elasticsearch
+    role: data
+  namespace: elasticsearch
+spec:
+  ports:
+  - port: 9300
+    name: transport
+  - port: 9200
+    name: http
+  - port: 9600
+    name: metrics
+  clusterIP: None
+  selector:
+    component: elasticsearch
+    role: data

--- a/open-distro-elasticsearch-kubernetes/elasticsearch/70-es-data-sts.yml
+++ b/open-distro-elasticsearch-kubernetes/elasticsearch/70-es-data-sts.yml
@@ -1,0 +1,156 @@
+# Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: MIT-0
+
+---
+apiVersion: apps/v1beta1
+kind: StatefulSet
+metadata:
+  labels:
+    component: elasticsearch
+    role: data
+  name: es-data
+  namespace: elasticsearch
+spec:
+  serviceName: elasticsearch-data
+  replicas: 3
+  template:
+    metadata:
+      labels:
+        component: elasticsearch
+        role: data
+      annotations:
+        iam.amazonaws.com/role: <ARN_OF_IAM_ROLE_FOR_CONTAINER>
+    spec:
+      # Add toleration for not scheduling on dedicated node
+      tolerations:
+      - key: dedicated
+        value: "true"
+        effect: NoSchedule
+      initContainers:
+      - name: init-sysctl
+        image: busybox:1.27.2
+        command:
+        - sysctl
+        - -w
+        - vm.max_map_count=262144
+        securityContext:
+          privileged: true
+      - name: fixmount
+        command: [ 'sh', '-c', 'chown -R 1000:1000 /usr/share/elasticsearch/data' ]
+        image: busybox
+        volumeMounts:
+          - mountPath: /usr/share/elasticsearch/data
+            name: data
+      # Weighted anti-affinity to disallow deploying client node to the same worker node as master node
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 1
+            podAffinityTerm:
+              topologyKey: "kubernetes.io/hostname"
+              labelSelector:
+                matchLabels:
+                  component: elasticsearch
+                  role: data
+        # Node Affinity to attract this Deployment's pods to a specific set of worker nodes
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: type # Replace this with corresponding worker node label's key
+                operator: In
+                values:
+                - general # Replace this with corresponding worker node label's value
+      serviceAccountName: elasticsearch
+      containers:
+      - name: elasticsearch
+        env:
+        - name: CLUSTER_NAME
+          value: logs
+        - name: NODE_MASTER
+          value: "false"
+        - name: NODE_INGEST
+          value: "false"
+        - name: NETWORK_HOST
+          value: "_eth0_"
+        - name: HTTP_ENABLE
+          value: "true"
+        - name: NUMBER_OF_MASTERS
+          value: "3"
+        - name: NODE_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: DISCOVERY_SERVICE
+          value: elasticsearch-discovery
+        - name: KUBERNETES_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: NODE_DATA
+          value: "true"
+        - name: PROCESSORS
+          valueFrom:
+            resourceFieldRef:
+              resource: limits.cpu
+        - name: ES_JAVA_OPTS
+          value: -Xms8g -Xmx8g
+        # Official Image from Open Distro Team
+        image: amazon/opendistro-for-elasticsearch:0.8.0
+        imagePullPolicy: Always
+        # only publish the transport port
+        ports:
+        - containerPort: 9300
+          name: transport
+        resources:
+          requests:
+            cpu: 2
+            memory: 16Gi
+          limits:
+            cpu: 2
+            memory: 16Gi
+        livenessProbe:
+          tcpSocket:
+            port: transport
+          initialDelaySeconds: 60
+          periodSeconds: 10
+        volumeMounts:
+        - mountPath: /usr/share/elasticsearch/data
+          name: data
+        - mountPath: /usr/share/elasticsearch/config/elasticsearch.yml
+          name: config
+          subPath: elasticsearch.yml
+        - mountPath: /usr/share/elasticsearch/config/logging.yml
+          name: config
+          subPath: logging.yml
+        - mountPath: /usr/share/elasticsearch/config/elk-crt.pem
+          name: config
+          subPath: elk-crt.pem
+        - mountPath: /usr/share/elasticsearch/config/elk-key.pem
+          name: config
+          subPath: elk-key.pem
+        - mountPath: /usr/share/elasticsearch/config/elk-root-ca.pem
+          name: config
+          subPath: elk-root-ca.pem
+        - mountPath: /usr/share/elasticsearch/config/admin-crt.pem
+          name: config
+          subPath: admin-crt.pem
+        - mountPath: /usr/share/elasticsearch/config/admin-key.pem
+          name: config
+          subPath: admin-key.pem
+        - mountPath: /usr/share/elasticsearch/config/admin-root-ca.pem
+          name: config
+          subPath: admin-root-ca.pem
+      volumes:
+      - name: config
+        configMap:
+          name: elasticsearch
+  volumeClaimTemplates:
+  - metadata:
+      name: data
+    spec:
+      accessModes: [ ReadWriteOnce ]
+      storageClassName: elk-gp2
+      resources:
+        requests:
+          storage: 2Ti

--- a/open-distro-elasticsearch-kubernetes/kibana/10-kb-namespace.yml
+++ b/open-distro-elasticsearch-kubernetes/kibana/10-kb-namespace.yml
@@ -1,0 +1,10 @@
+# Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: MIT-0
+
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: kibana
+  labels:
+    name: kibana

--- a/open-distro-elasticsearch-kubernetes/kibana/20-kb-configmap.yml
+++ b/open-distro-elasticsearch-kubernetes/kibana/20-kb-configmap.yml
@@ -1,0 +1,49 @@
+# Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: MIT-0
+
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: kibana
+  namespace: kibana
+  labels:
+    app: kibana
+data:
+  kibana.yml: |-
+    ---
+    # Default Kibana configuration from kibana-docker.
+    server.name: kibana
+    server.host: "0"
+
+    # Replace with Elasticsearch DNS name picked during Service deployment
+    elasticsearch.url: https://elk.sec.example.com:9200
+    elasticsearch.requestTimeout: 360000
+
+    # Kibana TLS Config
+    server.ssl.enabled: true
+    server.ssl.key: /usr/share/kibana/config/kibana-key.pem
+    server.ssl.certificate: /usr/share/kibana/config/kibana-crt.pem
+    server.ssl.keyPassphrase: ${KEY_PASSPHRASE}
+    elasticsearch.ssl.certificateAuthorities: /usr/share/kibana/config/kibana-root-ca.pem
+
+    opendistro_security.cookie.secure: true
+    opendistro_security.cookie.password: ${COOKIE_PASS}
+
+  kibana-crt.pem: |-
+    -----BEGIN CERTIFICATE-----
+    <CERTIFICATE_DATA_REDACTED>
+    -----END CERTIFICATE-----
+    -----BEGIN CERTIFICATE-----
+    <CERTIFICATE_DATA_REDACTED>
+    -----END CERTIFICATE-----
+
+  kibana-key.pem: |-
+    -----BEGIN ENCRYPTED PRIVATE KEY-----
+    <CERTIFICATE_DATA_REDACTED>
+    -----END ENCRYPTED PRIVATE KEY-----
+
+  kibana-root-ca.pem: |-
+    -----BEGIN CERTIFICATE-----
+    <CERTIFICATE_DATA_REDACTED>
+    -----END CERTIFICATE-----

--- a/open-distro-elasticsearch-kubernetes/kibana/30-kb-deploy.yml
+++ b/open-distro-elasticsearch-kubernetes/kibana/30-kb-deploy.yml
@@ -1,0 +1,76 @@
+# Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: MIT-0
+
+---
+apiVersion: apps/v1beta1
+kind: Deployment
+metadata:
+  name: kibana
+  namespace: kibana
+  labels:
+    component: kibana
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+     component: kibana
+  template:
+    metadata:
+      labels:
+        component: kibana
+    spec:
+      containers:
+      - name: kibana
+        # Official Image from Open Distro Team
+        image: amazon/opendistro-for-elasticsearch-kibana:0.8.0
+        env:
+        - name: CLUSTER_NAME
+          value: logs
+        - name: ELASTICSEARCH_USERNAME
+          value: kibanaserver
+        # Replace with password chosen during cluster initialization
+        - name: ELASTICSEARCH_PASSWORD
+          value: <PASSWORD_CHOSEN_DURING_CLUSTER_INITIALIZATION>
+        # Replace with key passphrase for key used to generate Kibana TLS cert
+        - name: KEY_PASSPHRASE
+          value: <PASSPHRASE_FOR_KIBANA_TLS_PRIVATE_KEY>
+        # 32-character random string to be used as cookie password by security plugin
+        - name: COOKIE_PASS
+          value: <COOKIE_PASS_FOR_SECURITY_PLUGIN_32CHARS>
+        resources:
+          limits:
+            cpu: 4
+            memory: 16Gi
+          requests:
+            cpu: 4
+            memory: 16Gi
+        readinessProbe:
+          tcpSocket:
+            port: http
+          initialDelaySeconds: 20
+          periodSeconds: 10
+        livenessProbe:
+          tcpSocket:
+            port: http
+          initialDelaySeconds: 20
+          periodSeconds: 10
+        ports:
+        - containerPort: 5601
+          name: http
+        volumeMounts:
+        - mountPath: /usr/share/kibana/config/kibana.yml
+          name: config
+          subPath: kibana.yml
+        - mountPath: /usr/share/kibana/config/elk-crt.pem
+          name: config
+          subPath: elk-crt.pem
+        - mountPath: /usr/share/kibana/config/elk-key.pem
+          name: config
+          subPath: elk-key.pem
+        - mountPath: /usr/share/kibana/config/elk-root-ca.pem
+          name: config
+          subPath: elk-root-ca.pem
+      volumes:
+      - name: config
+        configMap:
+          name: kibana

--- a/open-distro-elasticsearch-kubernetes/kibana/40-kb-service.yml
+++ b/open-distro-elasticsearch-kubernetes/kibana/40-kb-service.yml
@@ -1,0 +1,35 @@
+# Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: MIT-0
+
+kind: Service
+apiVersion: v1
+metadata:
+  name: kibana
+  namespace: kibana
+  labels:
+    app: kibana
+  annotations:
+    # Service external-dns has to be deployed for this A record to be created in AWS Route53
+    external-dns.alpha.kubernetes.io/hostname: kibana.sec.example.com
+
+    # Use ACM cert that is authorized for domain chosen above
+    # Replace with ARN of the working ACM cert
+    service.beta.kubernetes.io/aws-load-balancer-ssl-cert: "arn:aws:acm:us-east-1:111222333444:certificate/7ace9dc0-84fb-4eb6-b70b-059fc489cd20"
+    service.beta.kubernetes.io/aws-load-balancer-backend-protocol: "https"
+
+    # Maps traffic to 443
+    service.beta.kubernetes.io/aws-load-balancer-ssl-ports: "https"
+
+    # You may want to increment ELB idle conn timeout for problems with WebSockets and Server-Side Events
+    service.beta.kubernetes.io/aws-load-balancer-connection-idle-timeout: '3600'
+spec:
+  loadBalancerSourceRanges:
+    # Open to the world since Kibana is now auth-ed
+    - 0.0.0.0/0
+  type: LoadBalancer
+  selector:
+    component: kibana
+  ports:
+  - name: https
+    port: 443
+    targetPort: 5601


### PR DESCRIPTION
*Issue # [13](https://github.com/opendistro-for-elasticsearch/community/issues/13)*

*Description of changes: Added kubernetes manifests for an example deployment of Open distro. Next release will be a conversion of these manifests to Helm charts.*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
