### PR TITLE
Cleaning up the README.md to remove additional characters in the installation instructions

### DIFF
--- a/open-distro-elasticsearch-kubernetes/README.md
+++ b/open-distro-elasticsearch-kubernetes/README.md
@@ -55,6 +55,7 @@ Deploy the Elasticsearch client nodes using the command:
 kubectl apply -f 50-es-client-deploy.yml
 ```
 
+
 Check for the master node pods to come up using the command:
 
 ```

--- a/open-distro-elasticsearch-kubernetes/README.md
+++ b/open-distro-elasticsearch-kubernetes/README.md
@@ -52,7 +52,7 @@ If the log output contains the following message, it means that the Elasticsearc
 Deploy the Elasticsearch client nodes using the command:
 
 ```
-kubectl apply -f `50-es-client-deploy.yml`
+kubectl apply -f 50-es-client-deploy.yml
 ```
 
 Check for the master node pods to come up using the command:


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Removed the additional apostrophe's in the  kubectl apply -f 50-es-client-deploy.yml command of the README.md file.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
