### PR TITLE
Add ES ConfigMap to Initial Resource creation

### DIFF
--- a/open-distro-elasticsearch-kubernetes/README.md
+++ b/open-distro-elasticsearch-kubernetes/README.md
@@ -11,6 +11,7 @@ kubectl apply -f 10-es-namespace.yml
 kubectl apply -f 20-es-svc-discovery.yml
 kubectl apply -f 20-es-service-account.yml
 kubectl apply -f 25-es-sc-gp2.yml
+kubectl apply -f 30-es-configmap.yml
 kubectl apply -f 35-es-service.yml
 ```
 


### PR DESCRIPTION
Looks like this may have been missed, ES master pod will fail to start with FailedMount if this ConfigMap is not applied beforehand.

*Issue #, if available: N/A*

*Description of changes: Add ES ConfigMap to Initial Resource creation*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
