### PR TITLE
Minimum masters should be (master_eligible_nodes / 2) + 1

### DIFF
--- a/open-distro-elasticsearch-kubernetes/elasticsearch/30-es-configmap.yml
+++ b/open-distro-elasticsearch-kubernetes/elasticsearch/30-es-configmap.yml
@@ -35,7 +35,7 @@ data:
     discovery:
       zen:
         ping.unicast.hosts: ${DISCOVERY_SERVICE}
-        minimum_master_nodes: ${NUMBER_OF_MASTERS}
+        minimum_master_nodes: ${MIN_MASTERS}
 
     # TLS Configuration Transport Layer
     opendistro_security.ssl.transport.pemcert_filepath: elk-crt.pem

--- a/open-distro-elasticsearch-kubernetes/elasticsearch/40-es-master-deploy.yml
+++ b/open-distro-elasticsearch-kubernetes/elasticsearch/40-es-master-deploy.yml
@@ -61,8 +61,8 @@ spec:
         env:
         - name: CLUSTER_NAME
           value: logs
-        - name: NUMBER_OF_MASTERS
-          value: "3"
+        - name: MIN_MASTERS
+          value: "2"
         - name: NODE_MASTER
           value: "true"
         - name: NODE_INGEST

--- a/open-distro-elasticsearch-kubernetes/elasticsearch/50-es-client-deploy.yml
+++ b/open-distro-elasticsearch-kubernetes/elasticsearch/50-es-client-deploy.yml
@@ -64,8 +64,8 @@ spec:
         env:
         - name: CLUSTER_NAME
           value: logs
-        - name: NUMBER_OF_MASTERS
-          value: "3"
+        - name: MIN_MASTERS
+          value: "2"
         - name: NODE_MASTER
           value: "false"
         - name: NODE_INGEST

--- a/open-distro-elasticsearch-kubernetes/elasticsearch/70-es-data-sts.yml
+++ b/open-distro-elasticsearch-kubernetes/elasticsearch/70-es-data-sts.yml
@@ -81,8 +81,8 @@ spec:
           value: "REPLACE_WITH_TLS_PRIVATE_KEY_PASSPHRASE" # Replace this with the passphrase for the TLS private key
         - name: HTTP_TLS_PEM_PASS
           value: "REPLACE_WITH_TLS_PRIVATE_KEY_PASSPHRASE" # Replace this with the passphrase for the TLS private key
-        - name: NUMBER_OF_MASTERS
-          value: "3"
+        - name: MIN_MASTERS
+          value: "2"
         - name: NODE_NAME
           valueFrom:
             fieldRef:


### PR DESCRIPTION
NUMBER_OF_MASTERS set the config variable minimum_master_nodes so I have renamed it to better explain what it does. That should be set to the minimum number of master nodes for quorum to prevent spit brain, ie 2 with this configuration of 3 masters.

The current configuration of three means that if the Kubernetes node running the master suddenly disappears there will be an elasticsearch outage until Kubernetes creates a new master elsewhere as neither of the remaining two master eligible nodes will assume the role of master. Once this patch is applied there will be no outage as one of the remaining two master eligible nodes will assume the master role.

See https://www.elastic.co/guide/en/elasticsearch/reference/6.8/discovery-settings.html#minimum_master_nodes

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
