### PR TITLE
Add ES 7, add ip addresses to the ES record

### DIFF
--- a/pa-to-es/node_tracker.py
+++ b/pa-to-es/node_tracker.py
@@ -1,0 +1,46 @@
+'''
+Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+SPDX-License-Identifier: MIT-0
+
+This walks all of the combinations of metrics, dimensions, and aggregations.
+METRICS - contains descriptions of the metric to be pulled and the dimensions
+for that metric. See also the docs here:
+https://opendistro.github.io/for-elasticsearch-docs/docs/pa/reference/.
+'''
+import json
+
+import requests
+
+class NodeTracker():
+    ''' Discovers nodes in the cluster, and holds a map from node name to
+        ip address. Construct the object, then use ip() to retrieve the 
+        address from the node name.'''
+
+    def __init__(self):
+        ''' Constructs a local dict, and fills it.'''
+        self._nodes_map = dict()
+        self._retrieve_node_ids_and_ips()
+
+    def _retrieve_node_ids_and_ips(self):
+        ''' Use _cat/nodes to pull the name and IP for all of the nodes in
+            the cluster. '''
+        response = requests.get('https://localhost:9200/_nodes',
+            ### HACK ALERT !!! TODO TODO TODO!!! Add real auth ###
+            auth=('admin', 'admin'),
+            verify=False)
+        if int(response.status_code) >= 300:
+            raise Exception('Bad response code trying to get node names and ips') 
+        json_response = json.loads(response.text)
+        if 'nodes' not in json_response:
+            raise Exception('Bad response - no nodes') 
+        for node_id, values in json_response['nodes'].items():
+            self._nodes_map[node_id] = values['ip']
+
+    def ip(self, node_name):
+        if node_name in self._nodes_map:
+            return self._nodes_map[node_name]
+        raise ValueError('{} is not a recognized node name'.format(node_name))
+
+    def print_table(self):
+        for name, ip in self._nodes_map.items():
+            print(' {}    {}'.format(name, ip))

--- a/pa-to-es/requirements.txt
+++ b/pa-to-es/requirements.txt
@@ -1,0 +1,6 @@
+certifi==2019.6.16
+chardet==3.0.4
+idna==2.8
+pytz==2019.2
+requests==2.22.0
+urllib3==1.25.3

--- a/pa-to-es/template7.json
+++ b/pa-to-es/template7.json
@@ -7,14 +7,12 @@
         "number_of_shards": 1
     },
     "mappings": {
-        "log": {
-            "properties": {
-                "@timestamp": {
-                    "type": "date"
-                },
-                "node_ip": {
-                    "type": "ip"
-                }
+        "properties": {
+            "@timestamp": {
+                "type": "date"
+            },
+            "node_ip": {
+                "type": "ip"
             }
         }
     }


### PR DESCRIPTION
*Issues*
https://github.com/opendistro-for-elasticsearch/community/issues/100

*Description of changes:*

Handling ES 7.x

I've added a flag (--seven) for Elasticsearch 7.x. If you're using Open Distro 1.0.0+, you'll need to set that command-line flag. The flag disables the _type in the _bulk requests. I've also added a template7.json, with a corrected template for ES 7.x. PUT that template to the _template API before running pa-to-es.

Adding IP addresses to the records sent to ES

As requested in issue 100, I've added a class to call _nodes and pull a node name to IP address map. As each result is parsed, it looks up the IP address for all of the records for that node and includes them in the record sent to ES for each of the metric/agg/dim thruples.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
