### PR TITLE
removed hard coded busybox from helm template

### DIFF
--- a/open-distro-elasticsearch-kubernetes/helm/README.md
+++ b/open-distro-elasticsearch-kubernetes/helm/README.md
@@ -20,13 +20,13 @@ Due to the uniqueness of different users environments, this chart aims to cater 
 ## TL;DR
 ```
 ❯ helm package .
-❯ helm install opendistro-es-1.1.0.tgz --name opendistro-es
+❯ helm install opendistro-es-1.1.1.tgz --name opendistro-es
 ```
 
 ## Installing the Chart
 To install the chart with the release name `my-release`:
 
-`❯ helm install --name my-release opendistro-es-1.1.0.tgz`
+`❯ helm install --name my-release opendistro-es-1.1.1.tgz`
 
 The command deploys OpenDistro Kibana and Elasticsearch with its associated components (data statefulsets, masters, clients) on the Kubernetes cluster in the default configuration.
 

--- a/open-distro-elasticsearch-kubernetes/helm/opendistro-es/Chart.yaml
+++ b/open-distro-elasticsearch-kubernetes/helm/opendistro-es/Chart.yaml
@@ -23,4 +23,4 @@ maintainers:
 name: opendistro-es
 sources:
 - https://pages.git.viasat.com/ATG/charts
-version: 1.1.0
+version: 1.1.1

--- a/open-distro-elasticsearch-kubernetes/helm/opendistro-es/templates/elasticsearch/es-data-sts.yaml
+++ b/open-distro-elasticsearch-kubernetes/helm/opendistro-es/templates/elasticsearch/es-data-sts.yaml
@@ -60,7 +60,7 @@ spec:
           privileged: true
       - name: fixmount
         command: [ 'sh', '-c', 'chown -R 1000:1000 /usr/share/elasticsearch/data' ]
-        image: busybox
+        image: {{ .Values.elasticsearch.initContainer.image }}:{{ .Values.elasticsearch.initContainer.imageTag }}
         volumeMounts:
           - mountPath: /usr/share/elasticsearch/data
             name: data

--- a/open-distro-elasticsearch-kubernetes/helm/opendistro-es/templates/elasticsearch/es-master-sts.yaml
+++ b/open-distro-elasticsearch-kubernetes/helm/opendistro-es/templates/elasticsearch/es-master-sts.yaml
@@ -73,7 +73,7 @@ spec:
           privileged: true
       - name: fixmount
         command: [ 'sh', '-c', 'chown -R 1000:1000 /usr/share/elasticsearch/data' ]
-        image: busybox
+        image: {{ .Values.elasticsearch.initContainer.image }}:{{ .Values.elasticsearch.initContainer.imageTag }}
         volumeMounts:
           - mountPath: /usr/share/elasticsearch/data
             name: data


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/opendistro-for-elasticsearch/community/issues/145

*Description of changes:*
Removed harded coded reference to busybox, incremented helm chart minor version in template and readme.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
