### PR TITLE
Fix resource namespace

### DIFF
--- a/open-distro-elasticsearch-kubernetes/helm/opendistro-es/templates/elasticsearch/rolebinding.yaml
+++ b/open-distro-elasticsearch-kubernetes/helm/opendistro-es/templates/elasticsearch/rolebinding.yaml
@@ -18,6 +18,7 @@ metadata:
   labels:
 {{ include "opendistro-es.labels.standard" . | indent 4 }}
   name: {{ template "opendistro-es.fullname" . }}-elastic-rolebinding
+  namespace: {{ .Release.Namespace }}
 roleRef:
   kind: Role
   name: {{ template "opendistro-es.elasticsearch.serviceAccountName" . }}

--- a/open-distro-elasticsearch-kubernetes/helm/opendistro-es/templates/kibana/kibana-deployment.yaml
+++ b/open-distro-elasticsearch-kubernetes/helm/opendistro-es/templates/kibana/kibana-deployment.yaml
@@ -19,6 +19,7 @@ metadata:
   labels:
 {{ include "opendistro-es.labels.standard" . | indent 4 }}
   name: {{ template "opendistro-es.fullname" . }}-kibana
+  namespace: {{ .Release.Namespace }}
 spec:
   replicas: {{ .Values.kibana.replicas }}
   template:

--- a/open-distro-elasticsearch-kubernetes/helm/opendistro-es/templates/kibana/kibana-ingress.yml
+++ b/open-distro-elasticsearch-kubernetes/helm/opendistro-es/templates/kibana/kibana-ingress.yml
@@ -20,6 +20,7 @@ metadata:
   labels:
 {{ include "opendistro-es.labels.standard" . | indent 4 }}
   name: {{ template "opendistro-es.fullname" . }}-kibana
+  namespace: {{ .Release.Namespace }}
   annotations:
     {{- range $key, $value := .Values.kibana.ingress.annotations }}
       {{ $key }}: {{ $value | quote }}

--- a/open-distro-elasticsearch-kubernetes/helm/opendistro-es/templates/kibana/kibana-service.yaml
+++ b/open-distro-elasticsearch-kubernetes/helm/opendistro-es/templates/kibana/kibana-service.yaml
@@ -21,6 +21,7 @@ metadata:
   labels:
 {{ include "opendistro-es.labels.standard" . | indent 4 }}
   name: {{ template "opendistro-es.fullname" . }}-kibana-svc
+  namespace: {{ .Release.Namespace }}
 spec:
   ports:
   - name: kibana-svc

--- a/open-distro-elasticsearch-kubernetes/helm/opendistro-es/templates/kibana/rolebinding.yaml
+++ b/open-distro-elasticsearch-kubernetes/helm/opendistro-es/templates/kibana/rolebinding.yaml
@@ -18,6 +18,7 @@ metadata:
   labels:
 {{ include "opendistro-es.labels.standard" . | indent 4 }}
   name: {{ template "opendistro-es.fullname" . }}-kibana-rolebinding
+  namespace: {{ .Release.Namespace }}
 roleRef:
   kind: Role
   name: {{ template "opendistro-es.kibana.serviceAccountName" . }}


### PR DESCRIPTION
This PR includes 2 changes:

- Deploy kibana in the same namespaces as Opendistro, if you apply the yaml from helm templating kibana gets deployed in the "default" namespace
- Creates RoleBinding in the correct namespace, otherwise the PSP is not applied correctly


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
