### PR TITLE
Update APIs to nondeprecated

### DIFF
--- a/open-distro-elasticsearch-kubernetes/helm/opendistro-es/templates/elasticsearch/es-client-deploy.yaml
+++ b/open-distro-elasticsearch-kubernetes/helm/opendistro-es/templates/elasticsearch/es-client-deploy.yaml
@@ -13,7 +13,7 @@
 # permissions and limitations under the License.
 
 {{- if .Values.elasticsearch.client.enabled }}
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
@@ -23,6 +23,10 @@ metadata:
   namespace: {{ .Release.Namespace }}
 spec:
   replicas: {{ .Values.elasticsearch.client.replicas }}
+  selector:
+    matchLabels:
+      app: {{ template "opendistro-es.fullname" . }}
+      role: client
   template:
     metadata:
       labels:

--- a/open-distro-elasticsearch-kubernetes/helm/opendistro-es/templates/elasticsearch/es-data-sts.yaml
+++ b/open-distro-elasticsearch-kubernetes/helm/opendistro-es/templates/elasticsearch/es-data-sts.yaml
@@ -13,7 +13,7 @@
 # permissions and limitations under the License.
 
 {{ if .Values.elasticsearch.data.enabled }}
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   labels:
@@ -24,6 +24,10 @@ metadata:
 spec:
   serviceName: {{ template "opendistro-es.fullname" . }}-data-svc
   replicas: {{ .Values.elasticsearch.data.replicas }}
+  selector:
+    matchLabels:
+      app: {{ template "opendistro-es.fullname" . }}
+      role: data
   updateStrategy:
     type: {{ .Values.elasticsearch.data.updateStrategy }}
   template:

--- a/open-distro-elasticsearch-kubernetes/helm/opendistro-es/templates/elasticsearch/es-master-sts.yaml
+++ b/open-distro-elasticsearch-kubernetes/helm/opendistro-es/templates/elasticsearch/es-master-sts.yaml
@@ -13,7 +13,7 @@
 # permissions and limitations under the License.
 
 {{- if .Values.elasticsearch.master.enabled }}
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   labels:
@@ -23,6 +23,10 @@ metadata:
   namespace: {{ .Release.Namespace }}
 spec:
   replicas: {{ .Values.elasticsearch.master.replicas }}
+  selector:
+    matchLabels:
+      app: {{ template "opendistro-es.fullname" . }}
+      role: master
   updateStrategy:
     type: {{ .Values.elasticsearch.master.updateStrategy }}
   serviceName: {{ template "opendistro-es.fullname" . }}-discovery

--- a/open-distro-elasticsearch-kubernetes/helm/opendistro-es/templates/kibana/kibana-deployment.yaml
+++ b/open-distro-elasticsearch-kubernetes/helm/opendistro-es/templates/kibana/kibana-deployment.yaml
@@ -13,7 +13,7 @@
 # permissions and limitations under the License.
 
 {{- if .Values.kibana.enabled }}
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
@@ -21,6 +21,9 @@ metadata:
   name: {{ template "opendistro-es.fullname" . }}-kibana
 spec:
   replicas: {{ .Values.kibana.replicas }}
+  selector:
+    matchLabels:
+      app: {{ template "opendistro-es.fullname" . }}-kibana
   template:
     metadata:
       labels:

--- a/open-distro-elasticsearch-kubernetes/helm/opendistro-es/templates/psp.yml
+++ b/open-distro-elasticsearch-kubernetes/helm/opendistro-es/templates/psp.yml
@@ -12,7 +12,7 @@
 # permissions and limitations under the License.
 
 {{- if .Values.global.psp.create }}
-apiVersion: extensions/v1beta1
+apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:
   labels:


### PR DESCRIPTION
Upgrade the API version to make it compatible with  kubernetes 1.16

More info in https://kubernetes.io/blog/2019/07/18/api-deprecations-in-1-16/

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
