### PR TITLE
remove path from default values for kibana ingress

### DIFF
--- a/open-distro-elasticsearch-kubernetes/helm/opendistro-es/values.yaml
+++ b/open-distro-elasticsearch-kubernetes/helm/opendistro-es/values.yaml
@@ -54,9 +54,9 @@ kibana:
       # kubernetes.io/ingress.class: nginx
       # kubernetes.io/tls-acme: "true"
     labels: {}
-    path: /
     hosts:
       - chart-example.local
+      # - chart-example.local/kibana
     tls: []
     #  - secretName: chart-example-tls
     #    hosts:


### PR DESCRIPTION
fixes #149 

the default helm chart values for kibana ingress contains `kibana.ingress.path: /`

this value is non-functional and misleading.  the path is derived from the entries in kibana.ingress.hosts if they have an additional path beyond the domain.

this change removes `kibana.ingress.path` and provides a commented example in the values.yaml file to demonstrate how paths can be set correctly.