### PR TITLE
Bump image versions

### DIFF
--- a/open-distro-elasticsearch-kubernetes/helm/opendistro-es/values.yaml
+++ b/open-distro-elasticsearch-kubernetes/helm/opendistro-es/values.yaml
@@ -137,7 +137,7 @@ elasticsearch:
 
   initContainer:
     image: busybox
-    imageTag: 1.27.2
+    imageTag: 1
 
   ssl:
     transport:

--- a/open-distro-elasticsearch-kubernetes/helm/opendistro-es/values.yaml
+++ b/open-distro-elasticsearch-kubernetes/helm/opendistro-es/values.yaml
@@ -14,7 +14,7 @@
 kibana:
   enabled: true
   image: amazon/opendistro-for-elasticsearch-kibana
-  imageTag: 1.2.0
+  imageTag: 1.8.0
   replicas: 1
   port: 5601
   externalPort: 443
@@ -342,7 +342,7 @@ elasticsearch:
   maxMapCount: 262144
 
   image: amazon/opendistro-for-elasticsearch
-  imageTag: 1.2.0
+  imageTag: 1.8.0
 
   configDirectory: /usr/share/elasticsearch/config
 


### PR DESCRIPTION
This sets the default opendistro image versions to the latest available and sets the busybox image tag to `1` to receive minor and patch upgrades.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
