### PR TITLE
Add provision to add elasticsearch.keystore in helm chart

### DIFF
--- a/open-distro-elasticsearch-kubernetes/helm/opendistro-es/templates/elasticsearch/es-client-deploy.yaml
+++ b/open-distro-elasticsearch-kubernetes/helm/opendistro-es/templates/elasticsearch/es-client-deploy.yaml
@@ -74,6 +74,44 @@ spec:
         - vm.max_map_count={{ .Values.elasticsearch.maxMapCount }}
         securityContext:
           privileged: true
+      {{ if .Values.elasticsearch.keystore }}
+      - name: keystore
+        image: {{ .Values.elasticsearch.image }}:{{ .Values.elasticsearch.imageTag }}
+        command:
+          - sh
+          - -c
+          - |
+            #!/usr/bin/env bash
+            set -euo pipefail
+            elasticsearch-keystore create
+            for file in /tmp/keystoreSecrets/*/*; do
+              key=$(basename $file)
+              echo "Adding file $file to keystore key $key"
+              elasticsearch-keystore add-file "$key" "$file"
+            done
+            # Add the bootstrap password since otherwise the Elasticsearch entrypoint tries to do this on startup
+            if [ ! -z ${ELASTICSEARCH_PASSWORD+x} ]; then
+              echo 'Adding env $ELASTICSEARCH_PASSWORD to keystore as key bootstrap.password'
+              echo "$ELASTICSEARCH_PASSWORD" | elasticsearch-keystore add -x bootstrap.password
+            fi
+            cp -a /usr/share/elasticsearch/config/elasticsearch.keystore /tmp/keystore/
+        env:
+        - name: ELASTICSEARCH_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: {{ .Values.kibana.elasticsearchAccount.secret }}
+              key: password
+{{ if .Values.elasticsearch.extraEnvs }}
+{{ toYaml .Values.elasticsearch.extraEnvs | indent 5 }}
+{{ end }}
+        volumeMounts:
+        - name: keystore
+          mountPath: /tmp/keystore
+        {{- range .Values.elasticsearch.keystore }}
+        - name: keystore-{{ .secretName }}
+          mountPath: /tmp/keystoreSecrets/{{ .secretName }}
+        {{- end }}
+{{ end }}
       containers:
       - name: elasticsearch
         env:
@@ -103,6 +141,16 @@ spec:
               resource: limits.cpu
         - name: ES_JAVA_OPTS
           value: {{ .Values.elasticsearch.client.javaOpts }}
+        - name: ELASTICSEARCH_USERNAME
+          valueFrom:
+            secretKeyRef:
+              name: {{ .Values.kibana.elasticsearchAccount.secret }}
+              key: username
+        - name: ELASTICSEARCH_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: {{ .Values.kibana.elasticsearchAccount.secret }}
+              key: password
 {{- if .Values.elasticsearch.extraEnvs }}
 {{ toYaml .Values.elasticsearch.extraEnvs | indent 8 }}
 {{- end }}
@@ -173,6 +221,11 @@ spec:
           name: admin-certs
           subPath: admin-root-ca.pem
         {{- end }}
+        {{ if .Values.elasticsearch.keystore }}
+        - mountPath: /usr/share/elasticsearch/config/elasticsearch.keystore
+          name: keystore
+          subPath: elasticsearch.keystore
+        {{ end }}
       volumes:
       - name: config
         secret:
@@ -192,4 +245,12 @@ spec:
         secret:
           secretName: {{ .Values.elasticsearch.ssl.admin.existingCertSecret }}
       {{- end }}
+      {{- if .Values.elasticsearch.keystore }}
+      - name: keystore
+        emptyDir: {}
+      {{- range .Values.elasticsearch.keystore }}
+      - name: keystore-{{ .secretName }}
+        secret: {{ toYaml . | nindent 12 }}
+      {{- end }}
+      {{ end }}
 {{- end }}

--- a/open-distro-elasticsearch-kubernetes/helm/opendistro-es/templates/elasticsearch/es-data-sts.yaml
+++ b/open-distro-elasticsearch-kubernetes/helm/opendistro-es/templates/elasticsearch/es-data-sts.yaml
@@ -68,6 +68,44 @@ spec:
         volumeMounts:
           - mountPath: /usr/share/elasticsearch/data
             name: data
+      {{ if .Values.elasticsearch.keystore }}
+      - name: keystore
+        image: {{ .Values.elasticsearch.image }}:{{ .Values.elasticsearch.imageTag }}
+        command:
+          - sh
+          - -c
+          - |
+            #!/usr/bin/env bash
+            set -euo pipefail
+            elasticsearch-keystore create
+            for file in /tmp/keystoreSecrets/*/*; do
+              key=$(basename $file)
+              echo "Adding file $file to keystore key $key"
+              elasticsearch-keystore add-file "$key" "$file"
+            done
+            # Add the bootstrap password since otherwise the Elasticsearch entrypoint tries to do this on startup
+            if [ ! -z ${ELASTICSEARCH_PASSWORD+x} ]; then
+              echo 'Adding env $ELASTICSEARCH_PASSWORD to keystore as key bootstrap.password'
+              echo "$ELASTICSEARCH_PASSWORD" | elasticsearch-keystore add -x bootstrap.password
+            fi
+            cp -a /usr/share/elasticsearch/config/elasticsearch.keystore /tmp/keystore/
+        env:
+        - name: ELASTICSEARCH_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: {{ .Values.kibana.elasticsearchAccount.secret }}
+              key: password
+{{ if .Values.elasticsearch.extraEnvs }}
+{{ toYaml .Values.elasticsearch.extraEnvs | indent 5 }}
+{{ end }}
+        volumeMounts:
+        - name: keystore
+          mountPath: /tmp/keystore
+        {{- range .Values.elasticsearch.keystore }}
+        - name: keystore-{{ .secretName }}
+          mountPath: /tmp/keystoreSecrets/{{ .secretName }}
+        {{- end }}
+{{ end }}
       # Weighted anti-affinity to disallow deploying client node to the same worker node as master node
       affinity:
         podAntiAffinity:
@@ -112,6 +150,16 @@ spec:
               resource: limits.cpu
         - name: ES_JAVA_OPTS
           value: {{ .Values.elasticsearch.data.javaOpts }}
+        - name: ELASTICSEARCH_USERNAME
+          valueFrom:
+            secretKeyRef:
+              name: {{ .Values.kibana.elasticsearchAccount.secret }}
+              key: username
+        - name: ELASTICSEARCH_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: {{ .Values.kibana.elasticsearchAccount.secret }}
+              key: password
 {{- if .Values.elasticsearch.extraEnvs }}
 {{ toYaml .Values.elasticsearch.extraEnvs | indent 8 }}
 {{- end }}
@@ -181,6 +229,11 @@ spec:
           name: admin-certs
           subPath: admin-root-ca.pem
          {{- end }}
+        {{ if .Values.elasticsearch.keystore }}
+        - mountPath: /usr/share/elasticsearch/config/elasticsearch.keystore
+          name: keystore
+          subPath: elasticsearch.keystore
+        {{ end }}
       volumes:
       - name: config
         secret:
@@ -200,6 +253,14 @@ spec:
         secret:
           secretName: {{ .Values.elasticsearch.ssl.admin.existingCertSecret }}
       {{- end }}
+      {{- if .Values.elasticsearch.keystore }}
+      - name: keystore
+        emptyDir: {}
+      {{- range .Values.elasticsearch.keystore }}
+      - name: keystore-{{ .secretName }}
+        secret: {{ toYaml . | nindent 12 }}
+      {{- end }}
+      {{ end }}
   volumeClaimTemplates:
   - metadata:
       name: data

--- a/open-distro-elasticsearch-kubernetes/helm/opendistro-es/templates/elasticsearch/es-master-sts.yaml
+++ b/open-distro-elasticsearch-kubernetes/helm/opendistro-es/templates/elasticsearch/es-master-sts.yaml
@@ -81,6 +81,44 @@ spec:
         volumeMounts:
           - mountPath: /usr/share/elasticsearch/data
             name: data
+      {{ if .Values.elasticsearch.keystore }}
+      - name: keystore
+        image: {{ .Values.elasticsearch.image }}:{{ .Values.elasticsearch.imageTag }}
+        command:
+          - sh
+          - -c
+          - |
+            #!/usr/bin/env bash
+            set -euo pipefail
+            elasticsearch-keystore create
+            for file in /tmp/keystoreSecrets/*/*; do
+              key=$(basename $file)
+              echo "Adding file $file to keystore key $key"
+              elasticsearch-keystore add-file "$key" "$file"
+            done
+            # Add the bootstrap password since otherwise the Elasticsearch entrypoint tries to do this on startup
+            if [ ! -z ${ELASTICSEARCH_PASSWORD+x} ]; then
+              echo 'Adding env $ELASTICSEARCH_PASSWORD to keystore as key bootstrap.password'
+              echo "$ELASTICSEARCH_PASSWORD" | elasticsearch-keystore add -x bootstrap.password
+            fi
+            cp -a /usr/share/elasticsearch/config/elasticsearch.keystore /tmp/keystore/
+        env:
+        - name: ELASTICSEARCH_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: {{ .Values.kibana.elasticsearchAccount.secret }}
+              key: password
+{{ if .Values.elasticsearch.extraEnvs }}
+{{ toYaml .Values.elasticsearch.extraEnvs | indent 5 }}
+{{ end }}
+        volumeMounts:
+        - name: keystore
+          mountPath: /tmp/keystore
+        {{- range .Values.elasticsearch.keystore }}
+        - name: keystore-{{ .secretName }}
+          mountPath: /tmp/keystoreSecrets/{{ .secretName }}
+        {{- end }}
+{{ end }}
       containers:
       - name: elasticsearch
         env:
@@ -120,6 +158,16 @@ spec:
               resource: limits.cpu
         - name: ES_JAVA_OPTS
           value: {{ .Values.elasticsearch.master.javaOpts }}
+        - name: ELASTICSEARCH_USERNAME
+          valueFrom:
+            secretKeyRef:
+              name: {{ .Values.kibana.elasticsearchAccount.secret }}
+              key: username
+        - name: ELASTICSEARCH_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: {{ .Values.kibana.elasticsearchAccount.secret }}
+              key: password
 {{- if .Values.elasticsearch.extraEnvs }}
 {{ toYaml .Values.elasticsearch.extraEnvs | indent 8 }}
 {{- end }}
@@ -224,6 +272,11 @@ spec:
           subPath: tenants.yml
       {{- end }}
       {{- end }}
+        {{ if .Values.elasticsearch.keystore }}
+        - mountPath: /usr/share/elasticsearch/config/elasticsearch.keystore
+          name: keystore
+          subPath: elasticsearch.keystore
+        {{ end }}
       volumes:
       - name: config
         secret:
@@ -273,6 +326,14 @@ spec:
         secret:
           secretName: {{ .Values.elasticsearch.securityConfig.tenantsSecret }}
       {{- end }}
+      {{- if .Values.elasticsearch.keystore }}
+      - name: keystore
+        emptyDir: {}
+      {{- range .Values.elasticsearch.keystore }}
+      - name: keystore-{{ .secretName }}
+        secret: {{ toYaml . | nindent 12 }}
+      {{- end }}
+      {{ end }}
   volumeClaimTemplates:
   - metadata:
       name: data

--- a/open-distro-elasticsearch-kubernetes/helm/opendistro-es/values.yaml
+++ b/open-distro-elasticsearch-kubernetes/helm/opendistro-es/values.yaml
@@ -353,6 +353,7 @@ elasticsearch:
     # If not set and create is true, a name is generated using the fullname template
     name:
 
+  keystore: []
 
 nameOverride: ""
 fullnameOverride: ""


### PR DESCRIPTION
*https://github.com/opendistro-for-elasticsearch/community/issues/193*

* Add Elasticsearch Keystore capability
* Upgrade Helm chart to support kubernetes v1.16


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license
